### PR TITLE
fix: Correct enum syntax in User model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,5 +3,5 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  enum_role: { visitor: 0, owner: 1 }
+  enum role: { visitor: 0, owner: 1 }
 end


### PR DESCRIPTION
fix: Correct enum syntax in User model

- Change `enum_role` to `enum role` in user.rb
- Resolve syntax error in User model